### PR TITLE
Custom error message when Linux DE is not supported 

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,3 +36,9 @@
     left: 0;
     width: 100vw;
 }
+
+.inline_text_link {
+    display: inline;
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/frontend/src/StartStopButton.tsx
+++ b/frontend/src/StartStopButton.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@blueprintjs/core';
+import { Button, Text } from '@blueprintjs/core';
 import { useEffect } from 'react';
 
 import { StartProxy, StopProxy } from '../wailsjs/go/app/App';
-import { EventsOn } from '../wailsjs/runtime/runtime';
+import { BrowserOpenURL, EventsOn } from '../wailsjs/runtime/runtime';
 
 import { AppToaster } from './common/toaster';
 import { ProxyState } from './types';
@@ -21,6 +21,7 @@ enum ProxyActionKind {
   Stopping = 'stopping',
   Stopped = 'stopped',
   StopError = 'stopError',
+  UnsupportedDE = 'unsupportedDE',
 }
 
 interface ProxyAction {
@@ -58,6 +59,27 @@ export function StartStopButton({ proxyState, setProxyState }: StartStopButtonPr
           });
           setProxyState('off');
           break;
+        case ProxyActionKind.UnsupportedDE:
+          AppToaster.show({
+            message: (
+              <div>
+                System proxy configuration is currently only supported on GNOME. <br />
+                Follow{' '}
+                <Text
+                  onClick={() =>
+                    BrowserOpenURL('https://github.com/anfragment/zen/blob/master/docs/external/linux-proxy-conf.md')
+                  }
+                  className="inline_text_link"
+                >
+                  this guide
+                </Text>{' '}
+                to set the proxy on a per-app basis.
+              </div>
+            ),
+            intent: 'danger',
+          });
+          break;
+
         default:
           console.log('unknown proxy action', action);
       }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -139,7 +139,11 @@ func (a *App) StartProxy() (err error) {
 	}
 
 	if err := a.proxy.Start(); err != nil {
-		return fmt.Errorf("start proxy: %v", err)
+		if errors.Is(err, proxy.ErrUnsupportedDesktopEnvironment) {
+			a.eventsHandler.OnUnsupportedDE(err)
+		} else {
+			return fmt.Errorf("start proxy: %v", err)
+		}
 	}
 
 	a.proxyOn = true

--- a/internal/app/eventshandler.go
+++ b/internal/app/eventshandler.go
@@ -45,6 +45,7 @@ const (
 	proxyStopping   proxyState = "stopping"
 	proxyStopped    proxyState = "stopped"
 	proxyStopError  proxyState = "stopError"
+	unsupportedDE   proxyState = "unsupportedDE"
 )
 
 type proxyAction struct {
@@ -117,6 +118,13 @@ func (e *eventsHandler) OnProxyStopped() {
 func (e *eventsHandler) OnProxyStopError(err error) {
 	runtime.EventsEmit(e.ctx, proxyChannel, proxyAction{
 		Kind:  proxyStopError,
+		Error: fmt.Sprint(err),
+	})
+}
+
+func (e *eventsHandler) OnUnsupportedDE(err error) {
+	runtime.EventsEmit(e.ctx, proxyChannel, proxyAction{
+		Kind:  unsupportedDE,
 		Error: fmt.Sprint(err),
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -39,6 +39,10 @@ type Proxy struct {
 	ignoredHostsMu   sync.RWMutex
 }
 
+var (
+	ErrUnsupportedDesktopEnvironment = errors.New("system proxy configuration is currently only supported on GNOME")
+)
+
 func NewProxy(filter filter, certGenerator certGenerator, port int, ignoredHosts []string) (*Proxy, error) {
 	if filter == nil {
 		return nil, errors.New("filter is nil")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -97,6 +97,11 @@ func (p *Proxy) Start() error {
 	}()
 
 	if err := p.setSystemProxy(); err != nil {
+		// dont stop the proxy if setting the system proxy fails, as user can user can set it manually for each application
+		if errors.Is(err, ErrUnsupportedDesktopEnvironment) {
+			return err
+		}
+
 		if err := p.Stop(); err != nil {
 			log.Printf("error stopping proxy: %v", err)
 		}

--- a/internal/proxy/proxy_linux.go
+++ b/internal/proxy/proxy_linux.go
@@ -11,6 +11,10 @@ var exclusionListURLs = []string{
 	"https://raw.githubusercontent.com/anfragment/zen/main/proxy/exclusions/common.txt",
 }
 
+var (
+	ErrUnsupportedDesktopEnvironment = errors.New("system proxy configuration is currently only supported on GNOME")
+)
+
 func (p *Proxy) setSystemProxy() error {
 	if binaryExists("gsettings") {
 		commands := [][]string{
@@ -32,7 +36,7 @@ func (p *Proxy) setSystemProxy() error {
 	}
 	// TODO: add support for other desktop environments
 
-	return errors.New("system proxy configuration is currently only supported on GNOME")
+	return ErrUnsupportedDesktopEnvironment
 }
 
 func (p *Proxy) unsetSystemProxy() error {

--- a/internal/proxy/proxy_linux.go
+++ b/internal/proxy/proxy_linux.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -10,10 +9,6 @@ import (
 var exclusionListURLs = []string{
 	"https://raw.githubusercontent.com/anfragment/zen/main/proxy/exclusions/common.txt",
 }
-
-var (
-	ErrUnsupportedDesktopEnvironment = errors.New("system proxy configuration is currently only supported on GNOME")
-)
 
 func (p *Proxy) setSystemProxy() error {
 	if binaryExists("gsettings") {


### PR DESCRIPTION
Added custom error message when there is no `gsettings` binary with a link to this guide - https://github.com/anfragment/zen/blob/master/docs/external/linux-proxy-conf.md

closes #108 