### PR TITLE
Separate logger setup for production and non-production environments

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,38 +2,15 @@ package logger
 
 import (
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 const (
 	appName = "Zen"
 )
-
-func SetupLogger() error {
-	logsDir, err := getLogsDir(appName)
-	if err != nil {
-		return fmt.Errorf("get logs directory: %w", err)
-	}
-
-	fileLogger := &lumberjack.Logger{
-		Filename:   filepath.Join(logsDir, "application.log"),
-		MaxSize:    5,
-		MaxBackups: 5,
-		MaxAge:     1,
-		Compress:   true,
-	}
-
-	log.SetOutput(io.MultiWriter(os.Stdout, fileLogger))
-
-	return nil
-}
 
 func OpenLogsDirectory() error {
 	logsDir, err := getLogsDir(appName)

--- a/internal/logger/setuplogger_nonprod.go
+++ b/internal/logger/setuplogger_nonprod.go
@@ -1,0 +1,32 @@
+//go:build !prod
+
+package logger
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func SetupLogger() error {
+	logsDir, err := getLogsDir(appName)
+	if err != nil {
+		return fmt.Errorf("get logs directory: %w", err)
+	}
+
+	fileLogger := &lumberjack.Logger{
+		Filename:   filepath.Join(logsDir, "application.log"),
+		MaxSize:    5,
+		MaxBackups: 5,
+		MaxAge:     1,
+		Compress:   true,
+	}
+
+	log.SetOutput(io.MultiWriter(os.Stdout, fileLogger))
+
+	return nil
+}

--- a/internal/logger/setuplogger_prod.go
+++ b/internal/logger/setuplogger_prod.go
@@ -1,0 +1,30 @@
+//go:build prod
+
+package logger
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func SetupLogger() error {
+	logsDir, err := getLogsDir(appName)
+	if err != nil {
+		return fmt.Errorf("get logs directory: %w", err)
+	}
+
+	fileLogger := &lumberjack.Logger{
+		Filename:   filepath.Join(logsDir, "application.log"),
+		MaxSize:    5,
+		MaxBackups: 5,
+		MaxAge:     1,
+		Compress:   true,
+	}
+
+	log.SetOutput(fileLogger)
+
+	return nil
+}

--- a/tasks/build/Taskfile-darwin.yml
+++ b/tasks/build/Taskfile-darwin.yml
@@ -34,7 +34,7 @@ tasks:
   app:
     desc: Build the .app application bundle. The .app file will be placed in the build/bin directory.
     cmds:
-      - wails build -platform "darwin/{{default .ARCH64 .ARCH}}" -m -skipbindings -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'"
+      - wails build -platform "darwin/{{default .ARCH64 .ARCH}}" -m -skipbindings -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'" -tags prod
 
   dmg:
     desc: Create a DMG installer for the application. The DMG file will be placed in the build/bin directory.

--- a/tasks/build/Taskfile-linux.yml
+++ b/tasks/build/Taskfile-linux.yml
@@ -9,12 +9,12 @@ tasks:
   prod:
     desc: Create a production build of the application.
     cmds:
-      - wails build -o Zen -platform "linux/{{default .ARCH64 .ARCH}}" -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'" -m -skipbindings
+      - wails build -o Zen -platform "linux/{{default .ARCH64 .ARCH}}" -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'" -m -skipbindings -tags prod
   
   prod-noupdate: 
     desc: Create a production build of the application with self-updates disabled.
     cmds:
-      - wails build -o Zen -platform "linux/{{default .ARCH64 .ARCH}}" -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}' -X 'github.com/anfragment/zen/internal/selfupdate.noSelfUpdate=true'" -m -skipbindings
+      - wails build -o Zen -platform "linux/{{default .ARCH64 .ARCH}}" -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}' -X 'github.com/anfragment/zen/internal/selfupdate.noSelfUpdate=true'" -m -skipbindings -tags prod
 
   deps:
     desc: Install the apt dependencies required to create a production build.

--- a/tasks/build/Taskfile-windows.yml
+++ b/tasks/build/Taskfile-windows.yml
@@ -9,9 +9,9 @@ tasks:
   prod:
     desc: Create a production build of the application.
     cmds:
-      - wails build -o Zen.exe -platform "windows/{{default .ARCH64 .ARCH}}" -nsis -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'" -m -skipbindings
+      - wails build -o Zen.exe -platform "windows/{{default .ARCH64 .ARCH}}" -nsis -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}'" -m -skipbindings -tags prod
 
   prod-noupdate:
     desc: Create a production build of the application with self-updates disabled.
     cmds:
-      - wails build -o Zen.exe -platform "windows/{{default .ARCH64 .ARCH}}" -nsis -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}' -X 'github.com/anfragment/zen/internal/selfupdate.noSelfUpdate=true'" -m -skipbindings
+      - wails build -o Zen.exe -platform "windows/{{default .ARCH64 .ARCH}}" -nsis -ldflags "-X 'github.com/anfragment/zen/internal/cfg.Version={{.GIT_TAG}}' -X 'github.com/anfragment/zen/internal/selfupdate.noSelfUpdate=true'" -m -skipbindings -tags prod


### PR DESCRIPTION
Windows (when app is running as .exe) cannot write logs to both stdout and a file simultaneously. Therefore, in the production environment, logs are written only to a file, while in non-production environments, logs are written to both.