### PR TITLE
Move scriptlet/JS rule bundle injections to the top <body>

### DIFF
--- a/internal/jsrule/injector.go
+++ b/internal/jsrule/injector.go
@@ -1,6 +1,7 @@
 package jsrule
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -73,8 +74,7 @@ func (inj *Injector) Inject(req *http.Request, res *http.Response) error {
 	injection = append(injection, injectionEnd...)
 
 	htmlrewrite.ReplaceBodyContents(res, func(match []byte) []byte {
-		match = append(match, injection...)
-		return match
+		return bytes.Join([][]byte{injection, match}, nil)
 	})
 
 	return nil

--- a/internal/scriptlet/injector.go
+++ b/internal/scriptlet/injector.go
@@ -78,9 +78,7 @@ func (inj *Injector) Inject(req *http.Request, res *http.Response) error {
 	ruleInjection.Write(scriptClosingTag)
 
 	htmlrewrite.ReplaceBodyContents(res, func(match []byte) []byte {
-		match = append(match, inj.bundle...)
-		match = append(match, ruleInjection.Bytes()...)
-		return match
+		return bytes.Join([][]byte{inj.bundle, ruleInjection.Bytes(), match}, nil)
 	})
 
 	return nil


### PR DESCRIPTION
This change prioritizes parsing and initialization of the injections compared to first-party JS. In certain cases, like YT video ads, ad-blocking performance should get improved.