### PR TITLE
Remove all hosts from proxy/exclusions/common.txt

### DIFF
--- a/proxy/exclusions/common.txt
+++ b/proxy/exclusions/common.txt
@@ -2,12 +2,3 @@
 # This may be due to certificate pinning, other security measures or bugs in servers/Zen itself.
 # The proxy will not attempt to MITM hosts in this file.
 # If you find a host that doesn't work, add it here and submit a pull request.
-
-discord.com
-discord.gg
-discord.media
-
-chat.openai.com
-
-# https://github.com/anfragment/zen/issues/132
-reddit.com


### PR DESCRIPTION
### What does this PR do?
Removes hosts from the `common` HTTPS exclusions list. The issues that originally caused these hosts to be added to the list are no longer replicable.

### How did you verify your code works?
Manual testing. To replicate, comment out `common.txt` from `proxy_<platformname>.go` under `internal/proxy`.

### What are the relevant issues?
