### PR TITLE
Replace `path.Join` with `filepath.Join` for cross-platform compatibility

### DIFF
--- a/internal/certstore/diskcertstore.go
+++ b/internal/certstore/diskcertstore.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -61,9 +61,9 @@ func NewDiskCertStore(config config) (*DiskCertStore, error) {
 
 	cs := &DiskCertStore{}
 	cs.config = config
-	cs.folderPath = path.Join(cfg.DataDir, caFolderName)
-	cs.certPath = path.Join(cs.folderPath, certFilename)
-	cs.keyPath = path.Join(cs.folderPath, keyFilename)
+	cs.folderPath = filepath.Join(cfg.DataDir, caFolderName)
+	cs.certPath = filepath.Join(cs.folderPath, certFilename)
+	cs.keyPath = filepath.Join(cs.folderPath, keyFilename)
 
 	return cs, nil
 }

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 )
 
@@ -125,7 +125,7 @@ func init() {
 func NewConfig() (*Config, error) {
 	c := &Config{}
 
-	configFile := path.Join(ConfigDir, "config.json")
+	configFile := filepath.Join(ConfigDir, "config.json")
 	var configData []byte
 	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
 		configData, err = os.ReadFile(configFile)
@@ -158,7 +158,7 @@ func (c *Config) Save() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-	configFile := path.Join(ConfigDir, "config.json")
+	configFile := filepath.Join(ConfigDir, "config.json")
 	err = os.WriteFile(configFile, configData, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/blang/semver"
 )
@@ -64,7 +64,7 @@ func (c *Config) RunMigrations() {
 	}
 
 	var lastMigration string
-	lastMigrationFile := path.Join(ConfigDir, "last_migration")
+	lastMigrationFile := filepath.Join(ConfigDir, "last_migration")
 	if c.firstLaunch {
 		lastMigration = Version
 	} else {

--- a/internal/cfg/systemdirs_darwin.go
+++ b/internal/cfg/systemdirs_darwin.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const (
@@ -20,7 +20,7 @@ func getConfigDir() (string, error) {
 		return "", err
 	}
 
-	dir := path.Join(homeDir, "Library", "Application Support", appFolderName, configDirName)
+	dir := filepath.Join(homeDir, "Library", "Application Support", appFolderName, configDirName)
 	return dir, nil
 }
 
@@ -30,6 +30,6 @@ func getDataDir() (string, error) {
 		return "", err
 	}
 
-	dir := path.Join(homeDir, "Library", "Application Support", appFolderName)
+	dir := filepath.Join(homeDir, "Library", "Application Support", appFolderName)
 	return dir, nil
 }

--- a/internal/cfg/systemdirs_linux.go
+++ b/internal/cfg/systemdirs_linux.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const (
@@ -14,7 +14,7 @@ const (
 
 func getConfigDir() (string, error) {
 	if os.Getenv("XDG_CONFIG_HOME") != "" {
-		return path.Join(os.Getenv("XDG_CONFIG_HOME"), appFolderName), nil
+		return filepath.Join(os.Getenv("XDG_CONFIG_HOME"), appFolderName), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -22,12 +22,12 @@ func getConfigDir() (string, error) {
 		return "", err
 	}
 
-	return path.Join(homeDir, ".config", appFolderName), nil
+	return filepath.Join(homeDir, ".config", appFolderName), nil
 }
 
 func getDataDir() (string, error) {
 	if os.Getenv("XDG_DATA_HOME") != "" {
-		return path.Join(os.Getenv("XDG_DATA_HOME"), appFolderName), nil
+		return filepath.Join(os.Getenv("XDG_DATA_HOME"), appFolderName), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -35,5 +35,5 @@ func getDataDir() (string, error) {
 		return "", err
 	}
 
-	return path.Join(homeDir, ".local", "share", appFolderName), nil
+	return filepath.Join(homeDir, ".local", "share", appFolderName), nil
 }

--- a/internal/cfg/systemdirs_windows.go
+++ b/internal/cfg/systemdirs_windows.go
@@ -2,7 +2,7 @@ package cfg
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const (
@@ -14,7 +14,7 @@ func getConfigDir() (string, error) {
 	// use LOCALAPPDATA instead of APPDATA because the config includes some machine-specific data
 	// e.g. whether the CA has been installed
 	if os.Getenv("LOCALAPPDATA") != "" {
-		return path.Join(os.Getenv("LOCALAPPDATA"), appFolderName, configDirName), nil
+		return filepath.Join(os.Getenv("LOCALAPPDATA"), appFolderName, configDirName), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -22,12 +22,12 @@ func getConfigDir() (string, error) {
 		return "", err
 	}
 
-	return path.Join(homeDir, "AppData", "Local", appFolderName, configDirName), nil
+	return filepath.Join(homeDir, "AppData", "Local", appFolderName, configDirName), nil
 }
 
 func getDataDir() (string, error) {
 	if os.Getenv("LOCALAPPDATA") != "" {
-		return path.Join(os.Getenv("LOCALAPPDATA"), appFolderName), nil
+		return filepath.Join(os.Getenv("LOCALAPPDATA"), appFolderName), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -35,5 +35,5 @@ func getDataDir() (string, error) {
 		return "", err
 	}
 
-	return path.Join(homeDir, "AppData", "Local", appFolderName), nil
+	return filepath.Join(homeDir, "AppData", "Local", appFolderName), nil
 }


### PR DESCRIPTION
### What does this PR do?
Replaces uses of `path.Join` with `filepath.Join` in code handling filesystem operations.

From `path`'s documentation:
> The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the [path/filepath](https://pkg.go.dev/path/filepath) package.

### How did you verify your code works?
Manual testing

### What are the relevant issues?
