### PR TITLE
Add `account.booking.com` to the common proxy exclusions list

### DIFF
--- a/proxy/exclusions/common.txt
+++ b/proxy/exclusions/common.txt
@@ -2,3 +2,5 @@
 # This may be due to certificate pinning, other security measures or bugs in servers/Zen itself.
 # The proxy will not attempt to MITM hosts in this file.
 # If you find a host that doesn't work, add it here and submit a pull request.
+
+account.booking.com


### PR DESCRIPTION
### What does this PR do?
It appears that we're triggering Booking's bot protection during OTP sign-ins on https://account.booking.com/otp/email-code.
![otp-page-screenshot](https://github.com/user-attachments/assets/5f0a95b5-0297-4d86-8fcf-31287073f860)

During debugging, POST requests to https://account.booking.com/api/identity/authenticate/v1.0/otp/code/submit consistently fail with `error.code: ERROR_CODE__INVALID_OTP`.

Adding `account.booking.com` to the list of transparently proxied hosts seems to resolve the issue.

### How did you verify your code works?
Manual testing by adding `account.booking.com` to *Ignored Hosts* in the settings.

### What are the relevant issues?