### PR TITLE
Rewrite $third-party matching logic to rely exclusively on the Sec-Fetch-Site header

### DIFF
--- a/internal/networkrules/rulemodifiers/thirdparty.go
+++ b/internal/networkrules/rulemodifiers/thirdparty.go
@@ -2,7 +2,6 @@ package rulemodifiers
 
 import (
 	"net/http"
-	"strings"
 )
 
 // https://adguard.com/kb/general/ad-filtering/create-own-filters/#third-party-modifier
@@ -20,24 +19,15 @@ func (m *ThirdPartyModifier) Parse(modifier string) error {
 }
 
 func (m *ThirdPartyModifier) ShouldMatchReq(req *http.Request) bool {
-	if req.Header.Get("Sec-Fetch-Site") == "cross-site" {
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site
+	switch req.Header.Get("Sec-Fetch-Site") {
+	case "cross-site":
 		return !m.inverted
-	}
-
-	referer := req.Header.Get("Referer")
-	if referer == "" {
-		return false
-	}
-	targetHost := req.Host
-	refererURL, err := req.URL.Parse(referer)
-	if err != nil {
-		return false
-	}
-	refererHost := refererURL.Hostname()
-	if strings.HasSuffix(refererHost, targetHost) {
+	case "same-origin", "same-site":
 		return m.inverted
+	default:
+		return false
 	}
-	return !m.inverted
 }
 
 func (m *ThirdPartyModifier) ShouldMatchRes(_ *http.Response) bool {


### PR DESCRIPTION
### What does this PR do?
#### Fixes issues with the `$third-party` modifier by making it use the `Set-Fetch-Site` header.

Determining whether a request is "third-party" using the `Referer` header is unreliable. In the case of document requests, Referer may contain the URL of a page that **redirected** to the current page instead of the current page itself.

Additionally, the current implementation contains a bug on [this line](https://github.com/anfragment/zen/blob/e66aa0338e5aa17f74e45b1b3a7db4fe99bfc8f6/internal/networkrules/rulemodifiers/thirdparty.go#L37) (`refererHost` and `targetHost` should be swapped), leading to incorrect detection even when `Referer` has the expected value.

This PR resolves both issues by relying on [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site), which is a reliable indicator of whether a request is "third-party". Unlike Referer, it does not suffer from inconsistencies caused by user-initiated requests, as those are simply assigned the value `none`.

### How did you verify your code works?
Manual testing.

### What are the relevant issues?
