### PR TITLE
Do not block user initiated requests unless  modifier is present

### DIFF
--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -15,6 +15,7 @@ type ExceptionRule struct {
 
 	Modifiers          ExceptionModifiers
 	ModifyingModifiers []rulemodifiers.ModifyingModifier
+	Document           bool
 }
 
 type ExceptionModifiers struct {
@@ -29,6 +30,10 @@ type exceptionModifier interface {
 }
 
 func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
+	if r.Document && er.Document {
+		return true
+	}
+
 	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ModifyingModifiers) == 0 {
 		return true
 	}
@@ -96,6 +101,11 @@ func (er *ExceptionRule) ParseModifiers(modifiers string) error {
 			}
 			return strings.HasPrefix(m, kind)
 		}
+		if isKind("document") || isKind("doc") {
+			er.Document = true
+			continue
+		}
+
 		var modifier rulemodifiers.Modifier
 		isOr := false
 		switch {
@@ -103,9 +113,7 @@ func (er *ExceptionRule) ParseModifiers(modifiers string) error {
 			modifier = &rulemodifiers.DomainModifier{}
 		case isKind("method"):
 			modifier = &rulemodifiers.MethodModifier{}
-		case isKind("document"),
-			isKind("doc"),
-			isKind("xmlhttprequest"),
+		case isKind("xmlhttprequest"),
 			isKind("xhr"),
 			isKind("font"),
 			isKind("subdocument"),

--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -30,8 +30,8 @@ type exceptionModifier interface {
 }
 
 func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
-	if r.Document && er.Document {
-		return true
+	if er.Document && !r.Document {
+		return false
 	}
 
 	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ModifyingModifiers) == 0 {

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -1,0 +1,71 @@
+package exceptionrule
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/anfragment/zen/internal/networkrules/rule"
+)
+
+func TestExceptionRule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("'@@||page' should cancel '||page$document'", func(t *testing.T) {
+		filterName := "test"
+
+		er := &ExceptionRule{
+			RawRule:    "||example.com",
+			FilterName: &filterName,
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com$document",
+			FilterName: &filterName,
+		}
+		r.ParseModifiers("document")
+
+		want := true
+		if got := er.Cancels(r); got != want {
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
+		}
+	})
+
+	t.Run("'@@||page$document' should cancel '||page$document'", func(t *testing.T) {
+		filterName := "test"
+
+		er := &ExceptionRule{
+			RawRule:    "||example.com$document",
+			FilterName: &filterName,
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com$document",
+			FilterName: &filterName,
+		}
+		r.ParseModifiers("document")
+		er.ParseModifiers("document")
+
+		want := true
+		if got := er.Cancels(r); got != want {
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
+		}
+	})
+
+	t.Run("'@@||page$document' should not cancel '||page'", func(t *testing.T) {
+		filterName := "test"
+
+		er := &ExceptionRule{
+			RawRule:    "||example.com^$document",
+			FilterName: &filterName,
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com",
+			FilterName: &filterName,
+		}
+		er.ParseModifiers("document")
+
+		want := false
+		if got := er.Cancels(r); got != want {
+			fmt.Println(got, want)
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
+		}
+	})
+}

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -11,6 +11,8 @@ func TestExceptionRule(t *testing.T) {
 	t.Parallel()
 
 	t.Run("'@@||page' should cancel '||page$document'", func(t *testing.T) {
+		t.Parallel()
+
 		filterName := "test"
 
 		er := &ExceptionRule{
@@ -30,6 +32,8 @@ func TestExceptionRule(t *testing.T) {
 	})
 
 	t.Run("'@@||page$document' should cancel '||page$document'", func(t *testing.T) {
+		t.Parallel()
+
 		filterName := "test"
 
 		er := &ExceptionRule{
@@ -50,6 +54,8 @@ func TestExceptionRule(t *testing.T) {
 	})
 
 	t.Run("'@@||page$document' should not cancel '||page'", func(t *testing.T) {
+		t.Parallel()
+
 		filterName := "test"
 
 		er := &ExceptionRule{

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -107,7 +107,7 @@ func (rm *Rule) ParseModifiers(modifiers string) error {
 
 // ShouldMatchReq returns true if the rule should match the request.
 func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
-	if req.Header.Get("Sec-Fetch-User") == "?1" && !rm.Document {
+	if req.Header.Get("Sec-Fetch-User") == "?1" && req.Header.Get("Sec-Fetch-Dest") == "document" && !rm.Document {
 		return false
 	}
 

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -14,22 +14,20 @@ var _ MatchingModifier = (*ContentTypeModifier)(nil)
 var (
 	// secFetchDestMap maps Sec-Fetch-Dest header values to corresponding content type modifiers.
 	secFetchDestMap = map[string]string{
-		"document": "document",
-		"empty":    "xmlhttprequest",
-		"font":     "font",
-		"frame":    "subdocument",
-		"iframe":   "subdocument",
-		"image":    "image",
-		"object":   "object",
-		"script":   "script",
-		"style":    "stylesheet",
-		"audio":    "media",
-		"track":    "media",
-		"video":    "media",
+		"empty":  "xmlhttprequest",
+		"font":   "font",
+		"frame":  "subdocument",
+		"iframe": "subdocument",
+		"image":  "image",
+		"object": "object",
+		"script": "script",
+		"style":  "stylesheet",
+		"audio":  "media",
+		"track":  "media",
+		"video":  "media",
 	}
 	// aliases maps content type aliases to their canonical names.
 	aliases = map[string]string{
-		"doc": "document",
 		"css": "stylesheet",
 		"xhr": "xmlhttprequest",
 	}

--- a/internal/networkrules/rulemodifiers/domain_test.go
+++ b/internal/networkrules/rulemodifiers/domain_test.go
@@ -53,7 +53,7 @@ func TestDomainModifier(t *testing.T) {
 		reqWithoutReferer := &http.Request{}
 
 		want := true
-		if got := m.ShouldMatchReq(reqWithoutReferer); !got {
+		if got := m.ShouldMatchReq(reqWithoutReferer); got != want {
 			t.Errorf("domainModifier{%s}.ShouldMatchReq() = %v, want %v", modifier, got, want)
 		}
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -251,11 +251,6 @@ func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request) {
 	}
 	defer clientConn.Close()
 
-	if filterResp := p.filter.HandleRequest(connReq); filterResp != nil {
-		filterResp.Write(clientConn)
-		return
-	}
-
 	host, _, err := net.SplitHostPort(connReq.Host)
 	if err != nil {
 		log.Printf("splitting host and port(%s): %v", logger.Redacted(connReq.Host), err)


### PR DESCRIPTION
### What does this PR do?

This PR changes blocking strategy by respecting user initiated requests unless `$document` modifier is present in rule.

`||scriptlet-test.pages.dev` - does not block document, but blocks all requests made from that page
`||scriptlet-test.pages.dev^$document` - blocks entire document

Also exception rules should work as expected:

`@@||scriptlet-test.pages.dev` - should cancel all rules above (@anfragment let me know if I'm wrong)

### What are the relevant issues?

Closes #249
