### PR TITLE
$removeparam fixes and improvements

### DIFF
--- a/internal/networkrules/rulemodifiers/removeparam.go
+++ b/internal/networkrules/rulemodifiers/removeparam.go
@@ -81,7 +81,7 @@ func (rm *RemoveParamModifier) ModifyReq(req *http.Request) (modified bool) {
 		for param, values := range query {
 			filtered := values[:0]
 			for _, v := range values {
-				// Regexp rules match the entire query parameter, not just the value.
+				// Regexp rules match the entire query parameter, not just the name.
 				if rm.regexp.MatchString(param + "=" + v) {
 					modified = true
 				} else {
@@ -94,7 +94,7 @@ func (rm *RemoveParamModifier) ModifyReq(req *http.Request) (modified bool) {
 		for param, values := range query {
 			filtered := values[:0]
 			for _, v := range values {
-				// Regexp rules match the entire query parameter, not just the value.
+				// Regexp rules match the entire query parameter, not just the name.
 				if !rm.regexp.MatchString(param + "=" + v) {
 					modified = true
 				} else {

--- a/internal/networkrules/rulemodifiers/removeparam_test.go
+++ b/internal/networkrules/rulemodifiers/removeparam_test.go
@@ -109,90 +109,90 @@ func TestRemoveParamModifier(t *testing.T) {
 			expected bool
 		}{
 			{
-				"Should cancel - identical modifiers",
+				"identical modifiers - should cancel",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				true,
 			},
 			{
-				"Should cancel - empty",
+				"empty modifiers - should cancel",
 				RemoveParamModifier{},
 				RemoveParamModifier{},
 				true,
 			},
 			{
-				"Should not cancel - different param",
+				"modifiers with different \"param\" - should not cancel",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "user",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				false,
 			},
 			{
-				"Should not cancel - different kind",
+				"modifiers with different \"kind\" - should not cancel",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				RemoveParamModifier{
-					kind:   2,
+					kind:   removeparamKindExact,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				false,
 			},
 			{
-				"Should not cancel - different regex",
+				"modifiers with different \"regexp\" - should not cancel",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile("^[a-zA-Z]+$"),
 				},
 				false,
 			},
 			{
-				"Should cancel - both regex nil",
+				"modifiers with nil regexes - should cancel",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: nil,
 				},
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: nil,
 				},
 				true,
 			},
 			{
-				"Should not cancel - one regex nil, one non-nil",
+				"modifier with nil regex should not cancel with non-nil regex",
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: nil,
 				},
 				RemoveParamModifier{
-					kind:   1,
+					kind:   removeparamKindRegexp,
 					param:  "id",
 					regexp: regexp.MustCompile(`^\d+$`),
 				},

--- a/internal/networkrules/rulemodifiers/removeparam_test.go
+++ b/internal/networkrules/rulemodifiers/removeparam_test.go
@@ -1,12 +1,103 @@
 package rulemodifiers
 
 import (
+	"net/http"
 	"regexp"
 	"testing"
 )
 
 func TestRemoveParamModifier(t *testing.T) {
 	t.Parallel()
+
+	t.Run("ModifyReq", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			modifier RemoveParamModifier
+			url      string
+			want     string
+			modified bool
+		}{
+			{
+				name:     "generic removes all params",
+				modifier: RemoveParamModifier{kind: removeparamKindGeneric},
+				url:      "https://example.com/?id=123&name=test",
+				want:     "https://example.com/",
+				modified: true,
+			},
+			{
+				name:     "exact removes the specified param",
+				modifier: RemoveParamModifier{kind: removeparamKindExact, param: "id"},
+				url:      "https://example.com/?id=123&known=1&name=test",
+				want:     "https://example.com/?known=1&name=test",
+				modified: true,
+			},
+			{
+				name:     "exact leaves the URL unchanged if the param is not found",
+				modifier: RemoveParamModifier{kind: removeparamKindExact, param: "unknown"},
+				url:      "https://example.com/?id=123&name=test&known=1",
+				want:     "https://example.com/?id=123&name=test&known=1",
+				modified: false,
+			},
+			{
+				name:     "exact inverse removes all params except the specified one",
+				modifier: RemoveParamModifier{kind: removeparamKindExactInverse, param: "id"},
+				url:      "https://example.com/?id=123&name=test&known=1",
+				want:     "https://example.com/?id=123",
+				modified: true,
+			},
+			{
+				name:     "regexp removes matching params",
+				modifier: RemoveParamModifier{kind: removeparamKindRegexp, regexp: regexp.MustCompile(`id=\d+`)},
+				url:      "https://example.com/?id=123&name=test",
+				want:     "https://example.com/?name=test",
+				modified: true,
+			},
+			{
+				name:     "regexp leaves the URL unchanged if the param is not found",
+				modifier: RemoveParamModifier{kind: removeparamKindRegexp, regexp: regexp.MustCompile(`id=[a-z]+`)},
+				url:      "https://example.com/?id=123&name=test",
+				want:     "https://example.com/?id=123&name=test",
+				modified: false,
+			},
+			{
+				name:     "exact leaves the URL unchanged if the URL has no query params",
+				modifier: RemoveParamModifier{kind: removeparamKindGeneric},
+				url:      "https://example.com:443/",
+				want:     "https://example.com:443/",
+				modified: false,
+			},
+			{
+				name:     "for multiple values with the same key, only the matching values are removed",
+				modifier: RemoveParamModifier{kind: removeparamKindRegexp, regexp: regexp.MustCompile(`^id=\d+$`)},
+				url:      "https://example.com/?id=test0&id=1&id=2&id=3&id=test1&id=test2",
+				want:     "https://example.com/?id=test0&id=test1&id=test2",
+				modified: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequest("GET", tt.url, nil)
+				if err != nil {
+					t.Fatalf("Failed to create request: %v", err)
+				}
+
+				modified := tt.modifier.ModifyReq(req)
+				if modified != tt.modified {
+					t.Errorf("ModifyReq() modified = %v, want %v", modified, tt.modified)
+				}
+
+				got := req.URL.String()
+				if got != tt.want {
+					t.Errorf("ModifyReq() got URL = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
 
 	t.Run("cancels", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
### What does this PR do?
#### Fixes matching for regex rules
From uBo documentation's ["Static filter syntax"](https://github.com/gorhill/ublock/wiki/static-filter-syntax#removeparam):
> When using a literal regular expression, it gets tested against each query parameter **name-value pair** assembled into a single string as name=value.

Currently, `$removeparam` [matches only parameter names](https://github.com/anfragment/zen/blob/102f55a61fc7c66703d689b429521a23aefc012f/internal/networkrules/rulemodifiers/removeparam.go#L79). This PR updates the implementation to match full name-value pairs as per the documented behavior.

#### Introduces inversed regex matching 
For compatibility with AdGuard, the modifier now also allows regular expressions to be prefixed with `~`. Such modifiers remove name-value pairs that **do not** match the regex.

### How did you verify your code works?
New tests for `$removeparam`'s `ModifyReq` function.

### What are the relevant issues?
