### PR TITLE
Fix duplicate URL handling when adding filter list

### DIFF
--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -200,6 +200,12 @@ func (c *Config) AddFilterList(list FilterList) string {
 	c.Lock()
 	defer c.Unlock()
 
+	for _, existingList := range c.Filter.FilterLists {
+		if existingList.URL == list.URL {
+			return fmt.Sprintf("filter list with the URL '%s' already exists", list.URL)
+		}
+	}
+
 	c.Filter.FilterLists = append(c.Filter.FilterLists, list)
 	if err := c.Save(); err != nil {
 		log.Printf("failed to save config: %v", err)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where adding custom filter lists with duplicate URLs caused issues with enabling/disabling or removing them, by adding checks for duplicates.

### How did you verify your code works?

Manual testing.

### What are the relevant issues?

Closes #149
