### PR TITLE
Set self-update manifests URL to update-manifests.zenprivacy.net

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -29,7 +29,7 @@ var NoSelfUpdate = "false"
 var releaseTrack = "stable"
 
 // manifestsBaseURL is the base URL for fetching update manifests.
-const manifestsBaseURL = "https://zenprivacy.net/update-manifests"
+const manifestsBaseURL = "https://update-manifests.zenprivacy.net"
 
 type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)


### PR DESCRIPTION
### What does this PR do?
The change itself is self-explanatory. This lays the groundwork for https://github.com/anfragment/zen/pull/286 - the application should first be configured to fetch updates from the new subdomain. Only after that should the CI start uploading manifests to the new location.

### How did you verify your code works?

<!--
**Please describe your testing strategy**:

- If you performed manual testing, list the steps to verify correct functionality, including edge cases if applicable.
- If new or existing automated tests cover the functionality, explicitly mention them.
-->

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
