### PR TITLE
Update "Phishing URL Blocklist" to hosts format

### DIFF
--- a/internal/cfg/default-config.json
+++ b/internal/cfg/default-config.json
@@ -52,7 +52,7 @@
         "type": "malware"
       },
       {
-        "url": "https://malware-filter.gitlab.io/malware-filter/phishing-filter.txt",
+        "url": "https://malware-filter.gitlab.io/malware-filter/phishing-filter-hosts.txt",
         "name": "Phishing URL Blocklist",
         "enabled": true,
         "type": "malware"

--- a/internal/cfg/migrations.go
+++ b/internal/cfg/migrations.go
@@ -129,6 +129,17 @@ var migrations = map[string]func(c *Config) error{
 		}
 		return nil
 	},
+	"v0.11.3": func(c *Config) error {
+		for i, list := range c.Filter.FilterLists {
+			if list.URL == "https://malware-filter.gitlab.io/malware-filter/phishing-filter.txt" {
+				c.Filter.FilterLists[i].URL = "https://malware-filter.gitlab.io/malware-filter/phishing-filter-hosts.txt"
+			}
+		}
+		if err := c.Save(); err != nil {
+			return fmt.Errorf("save config: %v", err)
+		}
+		return nil
+	},
 }
 
 // RunMigrations runs the version-to-version migrations.


### PR DESCRIPTION
### What does this PR do?
Updates the URL of the "Phishing URL Blocklist" filter list to the hosts format. The current one contains a line with a single `&` character, which causes every request containing an ampersand in the URL to get blocked.

### How did you verify your code works?

### What are the relevant issues?
resolves #421