### PR TITLE
improve error wrapping in Set (sysproxy) for DE error handling

### DIFF
--- a/internal/sysproxy/manager.go
+++ b/internal/sysproxy/manager.go
@@ -46,7 +46,7 @@ func (m *Manager) Set(proxyPort int, userConfiguredExcludedHosts []string) error
 
 	pacURL := fmt.Sprintf("http://127.0.0.1:%d/proxy.pac", actualPort)
 	if err := setSystemProxy(pacURL); err != nil {
-		return fmt.Errorf("set system proxy with URL %q: %v", pacURL, err)
+		return fmt.Errorf("set system proxy with URL %q: %w", pacURL, err)
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

Fixes error handling to show proper error about DE support and still run proxy

This condition never passed: https://github.com/ZenPrivacy/zen-desktop/blob/master/internal/app/app.go#L228

### How did you verify your code works?

Manual testing, telnet

### What are the relevant issues?

https://github.com/ZenPrivacy/zen-desktop/issues/499

