### PR TITLE
Refactor separators slice to an array

### DIFF
--- a/internal/ruletree/node.go
+++ b/internal/ruletree/node.go
@@ -145,16 +145,14 @@ func (n *node[T]) traverse(url string) []T {
 	return data
 }
 
-var separators []bool
+var separators [256]bool
 
 func init() {
-	separators = make([]bool, 256)
-
 	for _, ch := range "~:/?#[]@!$&'()*+,;=" {
-		separators[int(ch)] = true
+		separators[ch] = true
 	}
 }
 
 func isSeparator(char byte) bool {
-	return separators[int(char)]
+	return separators[char]
 }


### PR DESCRIPTION
### What does this PR do?
Slightly improves the readability of the `separators` variable by refactoring it into an array.

### How did you verify your code works?
Existing RuleTree unit tests.

### What are the relevant issues?

