### PR TITLE
Minor proxy loop refactor/improvements

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -325,7 +325,6 @@ func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request) {
 		}
 		if err := resp.Body.Close(); err != nil {
 			log.Printf("closing body(%q): %v", logger.Redacted(connReq.Host), err)
-			break
 		}
 
 		if req.Close || resp.Close {


### PR DESCRIPTION
### What does this PR do?
Refactors the `proxyConect` loop:
- Skips logging errors caused by the closure of `clientConn`, which mostly occurs during normal operation. This cleans up application logs significantly.
- Allows for connection reuse after replying with a response from the `filter`.

### How did you verify your code works?
Manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
