### PR TITLE
Mitm exclusions

### DIFF
--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -55,6 +55,7 @@ bankffin.kz
 jusan.kz
 onlinebank.kz
 freedompay.kz
+wlp-acs.com
 
 # Payment processors
 paypal.com


### PR DESCRIPTION
### What does this PR do?

Add wlp-acs.com to the exclusions.

> wlp-acs.com is a domain used for payment verification. See [this](https://www.netify.ai/resources/domains/wlp-acs.com) for more details.


