### PR TITLE
Update zen-core to v1.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/ZenPrivacy/zen-desktop
 go 1.25.3
 
 require (
-	github.com/ZenPrivacy/zen-core v1.0.2
+	github.com/ZenPrivacy/zen-core v1.0.3
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/wailsapp/wails/v2 v2.10.2
 	golang.org/x/sys v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ZenPrivacy/zen-core v1.0.2 h1:Jtbb587ki0jhVRY644vyK1neDPSNeLFZG4cqC89Jqlo=
-github.com/ZenPrivacy/zen-core v1.0.2/go.mod h1:90KCSuaHdhBhORN3IxF5X2UUxW+69RzG+BhXb0htLzA=
+github.com/ZenPrivacy/zen-core v1.0.3 h1:eODCCgSVBfG3H/pkBndZBsDBLO1FLFVCCUYLXVMFQPs=
+github.com/ZenPrivacy/zen-core v1.0.3/go.mod h1:90KCSuaHdhBhORN3IxF5X2UUxW+69RzG+BhXb0htLzA=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
### What does this PR do?
Upgrades `zen-core` to v1.0.3. The new version of the packages removes a nil check for `myRules` in NewFilter, which fixes the associated issue.

### How did you verify your code works?
Manual testing with `v1.0.2` vs `v1.0.3` with unmodified, `default` config.

### What are the relevant issues?
resolves https://github.com/ZenPrivacy/zen-desktop/issues/516
