### PR TITLE
Fix Windows uninstaller failing to terminate Zen

### DIFF
--- a/build/windows/installer/project.nsi
+++ b/build/windows/installer/project.nsi
@@ -115,6 +115,8 @@ SectionEnd
 Section "uninstall" 
     !insertmacro wails.setShellContext
 
+    ExecWait 'Taskkill /F /IM "${PRODUCT_EXECUTABLE}" /T' ; Kill the running application if any
+
     # Run the executable with --uninstall-ca flag before removing it
     ExecWait '"$INSTDIR\${PRODUCT_EXECUTABLE}" --uninstall-ca'
 


### PR DESCRIPTION
### What does this PR do?
As described in https://github.com/ZenPrivacy/zen-desktop/issues/459 and recently reported in https://github.com/ZenPrivacy/zen-desktop/issues/528, the Windows uninstaller doesn't terminate the running Zen instance, which then prevents the binary from being removed. Combined with autostart, this results in a critical issue where Zen relaunches on every system startup even after being uninstalled.

This PR fixes the problem by executing
```powershell
Taskkill /F /IM "Zen.exe" /T
``` 
as the first step durning uninstallation, ensuring the remaining uninstall logic runs as expected.

### How did you verify your code works?
Manual testing on Windows:
1. `wails build -nsis`
2. Install the app from `build/bin`
3. Launch Zen and keep it running
4. Uninstall the app

After this change, Zen is properly closed, and the contents of `%LOCALAPPDATA\Programs\Zen` get removed.

### What are the relevant issues?
Resolves #459
Resolves #528
