### PR TITLE
Fixing Stop > Start > Start stopped working on unsupported system

### DIFF
--- a/internal/sysproxy/manager.go
+++ b/internal/sysproxy/manager.go
@@ -60,7 +60,13 @@ func (m *Manager) Clear() error {
 	}
 
 	if err := unsetSystemProxy(); err != nil {
-		return fmt.Errorf("unset system proxy: %v", err)
+		// FIX: If the desktop environment is unsupported (e.g., XFCE, i3), we log the error
+		// but proceed to close the server so the application state doesn't get stuck.
+		if errors.Is(err, ErrUnsupportedDesktopEnvironment) {
+			log.Printf("warning: clearing system proxy failed (unsupported desktop environment), proceeding to close server: %v", err)
+		} else {
+			return fmt.Errorf("unset system proxy: %v", err)
+		}
 	}
 
 	if err := m.server.Close(); err != nil {


### PR DESCRIPTION
### What does this PR do?

The zen-desktop application relies on a helper package (likely in zen-core) to configure the Linux system-wide proxy. Currently, that package only knows how to talk to GNOME (via gsettings) and KDE (via kwriteconfig).

When you click "Stop," the application tries to "clean up" by unsetting the system proxy. Since your desktop environment (DE) is likely something else (like XFCE, Sway, or i3), the cleanup fails with the error: system proxy configuration is currently only supported on GNOME and KDE

This is incredibly terrible UX experience, making it very hard to add rules to My Rules and test new rules.

### How did you verify your code works?

On Linux Mint, I'm now possible to Stop then Start Zen again

### What are the relevant issues?

Why the "Start" then breaks ?

 When the "Stop" command returns an error, the application state gets "stuck." The internal logic thinks the proxy is still half-active or in an error state, preventing the "Start" function from re-initializing the proxy engine.
