### PR TITLE
Normalize language selector ordering

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -37,7 +37,7 @@ export interface LocaleItem {
   label: string;
 }
 
-export const LOCALE_LABELS = [
+export const LOCALE_LABELS: LocaleItem[] = [
   { value: 'en-US', label: 'English' },
   { value: 'de-DE', label: 'Deutsch' },
   { value: 'kk-KZ', label: 'Қазақша' },
@@ -46,7 +46,7 @@ export const LOCALE_LABELS = [
   { value: 'zh-TW', label: '中文（繁體）' },
   { value: 'it-IT', label: 'Italiano' },
   { value: 'fr-FR', label: 'Français' },
-] satisfies LocaleItem[];
+];
 
 // Sort language options into a consistent, user-friendly alphabetical order.
 // Uses Unicode root collation ("und") to keep the order stable and identical for everyone.


### PR DESCRIPTION
### What does this PR do?

Sort language labels into user-friendly alphabetical order.
This matches common UX patterns (e.g. ChatGPT and Samsung One UI language selectors).

In the future, we may choose to rely on standard language metadata if the language list grows or becomes more complex, such as:
- [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
- [Language subtag exploration tools](https://r12a.github.io/app-subtags/)

_(I haven't digged into them too much though)_

### How did you verify your code works?

Manual testing.

