### PR TITLE
Taskfile.yml: add link-core and unlink-core commands for zen-core library management

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,3 +55,13 @@ tasks:
     cmds:
       - git subtree pull --prefix=internal/sysproxy/exclusions https://github.com/ZenPrivacy/zen-https-exclusions master --squash
 
+  link-core:
+    desc: Add local replace directive for zen-core in go.mod.
+    cmds:
+      - go mod edit -replace=github.com/ZenPrivacy/zen-core=../core
+
+  unlink-core:
+    desc: Remove local replace directive for zen-core from go.mod.
+    cmds:
+      - go mod edit -dropreplace=github.com/ZenPrivacy/zen-core
+


### PR DESCRIPTION
### What does this PR do?
Self-explanatory.

Makes local development slightly more convenient since we frequently run development versions of zen-core for testing.

See [`go mod edit`](https://go.dev/ref/mod#go-mod-edit) documentation for more details.

### How did you verify your code works?

Manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
