### PR TITLE
frontend: refetch filter lists state on filter list toggle

### DIFF
--- a/frontend/src/FilterLists/index.tsx
+++ b/frontend/src/FilterLists/index.tsx
@@ -97,6 +97,7 @@ export function FilterLists() {
             filterList={filterList}
             showDelete={type === FilterListType.CUSTOM}
             onRemoved={fetchLists}
+            onToggled={fetchLists}
           />
         ))}
 
@@ -110,11 +111,13 @@ export function FilterListItem({
   showDelete,
   showButtons = true,
   onRemoved,
+  onToggled,
 }: {
   filterList: cfg.FilterList;
   showDelete?: boolean;
   showButtons?: boolean;
   onRemoved?: () => void;
+  onToggled?: () => void;
 }) {
   const { t } = useTranslation();
   const { isProxyRunning } = useProxyState();
@@ -146,6 +149,7 @@ export function FilterListItem({
                 });
               }
               setSwitchLoading(false);
+              onToggled?.();
             }}
             size="large"
             className="filter-lists__list-switch"


### PR DESCRIPTION
### What does this PR do?

Introduces `onToggled` prop on `FilterListItem`, which fetches filter lists.

### How did you verify your code works?

Manual testing.

### What are the relevant issues?

Closes #572 
