### PR TITLE
Handle unsupported de error on proxy stop

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -279,7 +279,11 @@ func (a *App) StopProxy() (err error) {
 	}
 
 	if err := a.systemProxyManager.Clear(); err != nil {
-		return fmt.Errorf("clear system proxy: %v", err)
+		if errors.Is(err, sysproxy.ErrUnsupportedDesktopEnvironment) {
+			log.Printf("system proxy not cleared (unsupported desktop environment): %v", err)
+		} else {
+			return fmt.Errorf("clear system proxy: %w", err)
+		}
 	}
 
 	if err := a.proxy.Stop(); err != nil {

--- a/internal/sysproxy/manager.go
+++ b/internal/sysproxy/manager.go
@@ -60,7 +60,7 @@ func (m *Manager) Clear() error {
 	}
 
 	if err := unsetSystemProxy(); err != nil {
-		return fmt.Errorf("unset system proxy: %v", err)
+		return fmt.Errorf("unset system proxy: %w", err)
 	}
 
 	if err := m.server.Close(); err != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes bug when users with unsupported linux desktop environments could not stop the proxy.

### How did you verify your code works?

Manual testing

### What are the relevant issues?

Based on the original fix proposed in https://github.com/ZenPrivacy/zen-desktop/pull/550, with the implementation adjusted as discussed in review.