### PR TITLE
Update copyright year to 2026; update copyright holders to "Zen contributors"

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -5,7 +5,7 @@
 Zen, including its source code and all attached documentation, is licensed under the MIT License.
 
 ```
-Copyright (c) 2025 Zen Privacy Project Developers
+Copyright (c) 2026 Zen contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zen Privacy Project Developers
+Copyright (c) 2026 Zen contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/windows/installer/resources/eula.txt
+++ b/build/windows/installer/resources/eula.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zen Privacy Project Developers
+Copyright (c) 2026 Zen contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/frontend/src/SettingsManager/index.tsx
+++ b/frontend/src/SettingsManager/index.tsx
@@ -88,7 +88,7 @@ export function SettingsManager() {
             (<BrowserLink href={CHANGELOG_URL}>{t('settings.about.changelog')}</BrowserLink>)
           </span>
         </div>
-        <div>© 2025 Zen Privacy Project Developers</div>
+        <div>© 2026 Zen contributors</div>
         <Button
           variant="minimal"
           size="small"

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		Mac: &mac.Options{
 			About: &mac.AboutInfo{
 				Title:   constants.AppName,
-				Message: fmt.Sprintf("Your Comprehensive Ad-Blocker and Privacy Guard\nVersion: %s\n© 2025 Zen Privacy Project Developers", cfg.Version),
+				Message: fmt.Sprintf("Your Comprehensive Ad-Blocker and Privacy Guard\nVersion: %s\n© 2026 Zen contributors", cfg.Version),
 			},
 		},
 		HideWindowOnClose: runtime.GOOS == "darwin" || runtime.GOOS == "windows",

--- a/wails.json
+++ b/wails.json
@@ -14,6 +14,6 @@
     "productName": "Zen",
     "productVersion": "0.16.0",
     "comments": "Zen is a simple, free and efficient ad-blocker and privacy guard for Windows, macOS and Linux. Visit https://zenprivacy.net for more information.",
-    "copyright": "Copyright (c) 2025 Zen Privacy Project Developers. Licensed under MIT License."
+    "copyright": "Copyright (c) 2026 Zen contributors. Licensed under MIT License."
   }
 }


### PR DESCRIPTION
### What does this PR do?

The year update should be self-explanatory.

Re: the copyright notice change:
We are moving away from "Zen Privacy" as the project name (it's just Zen), which prompted the update to the copyright notice. This doesn't change anything about our open-source posture; just purely a labeling change.

### How did you verify your code works?

<!--
**Please describe your testing strategy**:

- If you performed manual testing, list the steps to verify correct functionality, including edge cases if applicable.
- If new or existing automated tests cover the functionality, explicitly mention them.
-->

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
