### PR TITLE
Fix updates failing to apply due to GitHub CDN slowness 

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -110,7 +110,7 @@ func (a *App) commonStartup(ctx context.Context) {
 	if err != nil {
 		log.Printf("failed to initialize self-updater: %v", err)
 	} else if su != nil {
-		go su.RunScheduledUpdateChecks(ctx)
+		go su.RunScheduledUpdateChecks()
 	}
 
 	time.AfterFunc(time.Second, func() {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,7 +1,6 @@
 package selfupdate
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -96,9 +95,7 @@ func NewSelfUpdater(config *cfg.Config, eventsEmitter eventsEmitter) (*SelfUpdat
 	return &u, nil
 }
 
-func (su *SelfUpdater) RunScheduledUpdateChecks(
-	ctx context.Context,
-) {
+func (su *SelfUpdater) RunScheduledUpdateChecks() {
 	check := func() bool {
 		policy := su.config.GetUpdatePolicy()
 		if policy != cfg.UpdatePolicyAutomatic {
@@ -123,14 +120,9 @@ func (su *SelfUpdater) RunScheduledUpdateChecks(
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-ctx.Done():
+	for range ticker.C {
+		if check() {
 			return
-		case <-ticker.C:
-			if check() {
-				return
-			}
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

- Increases `SelfUpdater`'s HTTP client's timeout to 5 minutes to fix failing updates due to slow downloads (#594)
- Simplifies `NewSelfUpdater`; adds fast exit if the app shouldn't self-update
- Removes automatic app restarts after updates since updates may now take much longer

### How did you verify your code works?

Manual testing.

### What are the relevant issues?

closes #594 