### PR TITLE
Pull the latest HTTPS exclusions

### DIFF
--- a/internal/sysproxy/exclusions/common.txt
+++ b/internal/sysproxy/exclusions/common.txt
@@ -56,6 +56,7 @@ jusan.kz
 onlinebank.kz
 freedompay.kz
 wlp-acs.com
+homebank.kz
 
 # Payment processors
 paypal.com
@@ -123,3 +124,5 @@ ws.chatgpt.com
 account.booking.com
 # https://github.com/ZenPrivacy/zen-desktop/issues/407
 updates.ghub.logitechg.com
+# https://github.com/ZenPrivacy/zen-https-exclusions/issues/3
+steamserver.net


### PR DESCRIPTION
### What does this PR do?

Pulls the latest exclusions from https://github.com/ZenPrivacy/zen-https-exclusions.

See https://github.com/ZenPrivacy/zen-https-exclusions/issues/3 for the primary motivation behind this.

### How did you verify your code works?

<!--
**Please describe your testing strategy**:

- If you performed manual testing, list the steps to verify correct functionality, including edge cases if applicable.
- If new or existing automated tests cover the functionality, explicitly mention them.
-->

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
