### PR TITLE
Fix macOS Login Items displaying developer name instead of app name

### DIFF
--- a/internal/autostart/autostart_darwin.go
+++ b/internal/autostart/autostart_darwin.go
@@ -13,8 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"text/template"
-
-	"github.com/ZenPrivacy/zen-desktop/internal/constants"
 )
 
 const (
@@ -30,8 +28,6 @@ const (
 		<array>
 			<string>{{.ReverseDNSAppName}}</string>
 		</array>
-		<key>ServiceDescription</key>
-		<string>{{.AppName}}</string>
 		<key>Program</key>
 		<string>{{.Program}}</string>
 		<key>ProgramArguments</key>
@@ -52,7 +48,6 @@ const (
 type plistTemplateParameters struct {
 	Program           string
 	ReverseDNSAppName string
-	AppName           string
 }
 
 func (m Manager) IsEnabled() (enabled bool, err error) {
@@ -112,7 +107,6 @@ func (m Manager) Enable() (err error) {
 	if err := t.Execute(f, plistTemplateParameters{
 		ReverseDNSAppName: reverseDNSAppName,
 		Program:           execPath,
-		AppName:           constants.AppName,
 	}); err != nil {
 		return fmt.Errorf("execute template: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue on macOS where Zen's autostart process displays the developer's name and a generic terminal icon under System Settings / Login Items, instead of "Zen" and the app icon.
It adds ServiceDescription and AssociatedBundleIdentifiers to the macOS launchd plist template in `autostart_darwin.go`.

### How did you verify your code works?
Compiled the app locally for macOS (darwin/arm64) to ensure the template changes compile without errors.
<img width="468" height="230" alt="image" src="https://github.com/user-attachments/assets/9855463c-c199-4dac-88d4-c997cc78f054" />

### What are the relevant issues?

Closes #625 